### PR TITLE
Fix evox related bugs

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,8 +12,6 @@ from pulse import Pulse
 from utils import *
 
 def conditional_transform(alg, lb, ub, n_dims):
-    if isinstance(alg, Pulse):
-        return lambda x: bitstring_to_real_number(x, lb, ub, n_dims)
     return None
 
 
@@ -53,10 +51,13 @@ for x in range(n_seeds):
 
     for i, algo in enumerate(algorithm_list):
         print(f'\n\nSeed {x+1} - Algorithm working on functions: {str(algo).split('.')[-1].split(' object')[0]}\n{"-"*39}')
-        sol_transform = conditional_transform(algo, -100, 100, 20)
+        if isinstance(algo, Pulse):
+            sol_transforms = [lambda x: decode_solution(x, -10, 10, 20)]
+        else:
+            sol_transforms = []
         for j, function in enumerate(problem_set):
             monitor = monitors.StdSOMonitor()
-            workflow = workflows.StdWorkflow(algo, function, monitors=[monitor], sol_transforms=[sol_transform])
+            workflow = workflows.StdWorkflow(algo, function, monitors=[monitor], sol_transforms=sol_transforms)
             # 1 sol_transforms=[bitstring_to_real_number], this is where i must turn my 400 bits into 20 numbers ?
             # i'm assuming we must create a function for that in utils for example and call her here?
             # and what if i need sol transform just in pulse but not in PSO, DE etc?

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,5 @@
+from jax import jit, vmap
+from functools import partial
 import pandas as pd
 import seaborn as sns
 import jax.numpy as jnp
@@ -6,38 +8,68 @@ import warnings
 
 warnings.filterwarnings("ignore")
 
-def bitstring_to_real_number(bitstring, lb, ub, n_dims):
-    bits_per_dim = len(bitstring) // n_dims
-    real_numbers = []
-    for i in range(n_dims):
-        start = i * bits_per_dim
-        end = (i + 1) * bits_per_dim
-        binary = bitstring[start:end]
-        decimal = jnp.sum(binary * (2 ** jnp.arange(bits_per_dim)[::-1]))
-        normalized = decimal / (2 ** bits_per_dim - 1)
-        real_number = lb + (ub - lb) * normalized
-        real_numbers.append(real_number)
-    return jnp.array(real_numbers)
 
+@partial(jit, static_argnums=[3])  # n_dims is static
+def decode_solution(bitstring_population, lb, ub, n_dims):
+    """bitstring_population (pop_size, n_dims * bits_per_dim)"""
+    return vmap(partial(_bitstring_to_real_number, lb, ub, n_dims))(
+        bitstring_population
+    )
+
+
+def _bitstring_to_real_number(lb, ub, n_dims, bitstring):
+    bits_per_dim = len(bitstring) // n_dims
+    bitstring = bitstring.reshape(-1, bits_per_dim)
+    real_numbers = vmap(partial(_decode_real_number, lb, ub, bits_per_dim))(bitstring)
+    return real_numbers.reshape(-1)
+
+
+def _decode_real_number(lb, ub, bits_per_dim, binary):
+    """Decode a single real number
+    Binary is a bool array. lb and ub defines the lower and upper bound of the range.
+    """
+    decimal = jnp.sum(binary * (2 ** jnp.arange(bits_per_dim)[::-1]))
+    normalized = decimal / (2**bits_per_dim - 1)
+    real_number = lb + (ub - lb) * normalized
+    return real_number
 
 
 def compile_and_boxplot(functions_final_fitness, n_seeds, save_fig=False):
-    """ Transforms our array of final results in order to create plot with ABF (average best fitness) distributions for all algorithms."""
+    """Transforms our array of final results in order to create plot with ABF (average best fitness) distributions for all algorithms."""
 
-    function_names = ['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12']
-    algo_names = ['PSO', 'CMA-ES', 'DE']
-    seed_names = [f'Seed {i + 1}' for i in range(n_seeds)]
+    function_names = [
+        "f1",
+        "f2",
+        "f3",
+        "f4",
+        "f5",
+        "f6",
+        "f7",
+        "f8",
+        "f9",
+        "f10",
+        "f11",
+        "f12",
+    ]
+    algo_names = ["PSO", "CMA-ES", "DE"]
+    seed_names = [f"Seed {i + 1}" for i in range(n_seeds)]
 
     """Turning the results array into a list of dataframes (one df for each function)."""
-    cec_2022 = [pd.DataFrame(functions_final_fitness[i, :, :]).transpose()
-                for i in range(functions_final_fitness.shape[0])]
+    cec_2022 = [
+        pd.DataFrame(functions_final_fitness[i, :, :]).transpose()
+        for i in range(functions_final_fitness.shape[0])
+    ]
     for df in cec_2022:
         df.columns = algo_names
         df.index = seed_names
 
     fig, axs = plt.subplots(4, 3, figsize=(14, 10))
     k, i, j = 0, 0, 0
-    colors = {'PSO': 'c', 'CMA-ES': 'darkviolet', 'DE': 'orange'}  # 'P\'': 'r', 'P': 'darkorange', 'SA': 'g'}
+    colors = {
+        "PSO": "c",
+        "CMA-ES": "darkviolet",
+        "DE": "orange",
+    }  # 'P\'': 'r', 'P': 'darkorange', 'SA': 'g'}
 
     for function in cec_2022:
         function_name = function_names[k]
@@ -45,14 +77,19 @@ def compile_and_boxplot(functions_final_fitness, n_seeds, save_fig=False):
             j = 0
             i += 1
 
-        sns.boxplot(data=function, ax=axs[i, j], palette=colors, flierprops={"marker": 'D', 'markerfacecolor': 'white', 'markersize': 3})
-        axs[i, j].set_title(r'Function $\mathit{{{}}}$'.format(function_name))
-        axs[i, j].set_yscale('log')
+        sns.boxplot(
+            data=function,
+            ax=axs[i, j],
+            palette=colors,
+            flierprops={"marker": "D", "markerfacecolor": "white", "markersize": 3},
+        )
+        axs[i, j].set_title(r"Function $\mathit{{{}}}$".format(function_name))
+        axs[i, j].set_yscale("log")
         axs[i, j].set_xticklabels(algo_names, rotation=270)
         # axs[i,j].set_yticklabels(algo_names, rotation=0)
         axs[i, j].tick_params(left=False, bottom=False)
-        axs[i, j].spines['top'].set_visible(False)
-        axs[i, j].spines['right'].set_visible(False)
+        axs[i, j].spines["top"].set_visible(False)
+        axs[i, j].spines["right"].set_visible(False)
 
         if j == 0:
             axs[i, j].set_ylabel("ABF")
@@ -67,5 +104,3 @@ def compile_and_boxplot(functions_final_fitness, n_seeds, save_fig=False):
         plt.savefig("resources/boxplot_test.png", bbox_inches="tight")
 
     plt.show()
-
-


### PR DESCRIPTION
This pr will fix evox related bugs and the code should now run successfully (except for the plotting part).
Major Changes:
1. Improved `bitstring_to_real_number`
2. Fix `sol_transform` usage
3. Fix various shape-related bugs.

Thing to notice:
1. There were some shape-related bugs in `full_tournment`, I assume there should be `pop_size / 2` parents1, `pop_size / 2` parents2, and `pop_size / 2` perfs, so that in the end, there will be `pop_size / 2` pairs, and `pop_size` offspring. Please check this part of the code.
2. The shape of the `state.parents` and `state.parents_index` is corrected as it represents pairs of parents. But I didn't check if this change could affect `_update_variables` and `_update_contrib`, please check this part.
3. `compile_and_boxplot` is not modified, it's only a side effect from code formatting, and I'm too lazy to kick it from that commit, so... :(

And in response to the `# what is this for in the general code?`
This part declares the state of the algorithm. Since jax needs to compile the code and requires the shape and dtype of variables to do so, it is best to declare these variables beforehand.

